### PR TITLE
#48 지원자 상세 조회 모달__GET API 제작 및 더미데이터 추가

### DIFF
--- a/src/interfaces/_applicantDetailInterface.ts
+++ b/src/interfaces/_applicantDetailInterface.ts
@@ -1,0 +1,16 @@
+import type { ApplicantStatus } from './_applicantInterface.js'
+
+export interface ApplicantDetail {
+  id: number
+  nickname: string
+  profile_image: string
+  introduction: string
+  motivation: string
+  goal: string
+  available_times: string[]
+  has_study_experience: boolean
+  study_experience_detail: string
+  status: ApplicantStatus
+  created_at: string
+  gender: string
+}

--- a/src/routers/recruit/dummy/manageDeatilModal/_dummyApplicantDetail.ts
+++ b/src/routers/recruit/dummy/manageDeatilModal/_dummyApplicantDetail.ts
@@ -1,0 +1,38 @@
+import type { ApplicantDetail } from '@/interfaces/_applicantDetailInterface.js'
+
+export const dummyApplicantDetail: ApplicantDetail[] = [
+  {
+    id: 12,
+    nickname: '홍길동',
+    profile_image: 'https://cdn.example.com/profiles/juwon.png',
+    introduction:
+      '안녕하세요! 프론트엔드 개발을 배우고 있는 홍길동입니다. 현재 React를 활용한 프로젝트를 진행하고 있으며, Unity를 통한 게임 개발에 관심이 생겨 지원했습니다.',
+    motivation:
+      'Unity 게임 개발을 통해 새로운 영역에 도전하고 싶습니다. 특히 3D 게임 개발 경험을 쌓고 향후 게임 개발자로 전향하는 것이 목표입니다.',
+    goal: '3개월 후에는 Unity를 활용한 완성도 높은 3D 게임을 개발할 수 있는 능력을 갖추고 싶습니다.',
+    available_times: ['월 18:00-20:00', '수 19:00-21:00'],
+    has_study_experience: true,
+    study_experience_detail:
+      '작년에 React 스터디를 6개월간 진행했으며, 팀 프로젝트로 쇼핑몰 웹사이트를 완성했습니다.',
+    status: 'pending',
+    created_at: '2024-11-25 14:30',
+    gender: '남성',
+  },
+  {
+    id: 13,
+    nickname: 'frontend_park',
+    gender: '여성',
+    profile_image: 'https://cdn.example.com/profiles/juwon.png',
+    introduction:
+      '안녕하세요! 프론트엔드 개발을 배우고 있는 홍길동입니다. 현재 React를 활용한 프로젝트를 진행하고 있으며, Unity를 통한 게임 개발에 관심이 생겨 지원했습니다.',
+    motivation:
+      'Unity 게임 개발을 통해 새로운 영역에 도전하고 싶습니다. 특히 3D 게임 개발 경험을 쌓고 향후 게임 개발자로 전향하는 것이 목표입니다.',
+    goal: '3개월 후에는 Unity를 활용한 완성도 높은 3D 게임을 개발할 수 있는 능력을 갖추고 싶습니다.',
+    available_times: ['월 18:00-20:00', '수 19:00-21:00'],
+    has_study_experience: false,
+    study_experience_detail:
+      '작년에 React 스터디를 6개월간 진행했으며, 팀 프로젝트로 쇼핑몰 웹사이트를 완성했습니다.',
+    status: 'accepted',
+    created_at: '2025-10-15 19:48',
+  },
+]

--- a/src/routers/recruit/recruitRouter.ts
+++ b/src/routers/recruit/recruitRouter.ts
@@ -11,6 +11,7 @@ import dummyRecruitDetailBase from './dummy/dummyRecruitDetail/_dummyRecruitDeta
 import type { RecruitDetail } from '@/interfaces/_recruitInterfaces.js'
 import dummyRecruitDetailBookmark from './dummy/dummyRecruitDetail/_dummyRecruitDetailBookmark.js'
 import fs from 'fs'
+import { dummyApplicantDetail } from './dummy/manageDeatilModal/_dummyApplicantDetail.js'
 
 // /recruitments
 const recruitRouter = express.Router()
@@ -201,6 +202,24 @@ recruitRouter.get('/:recruitment_id/applications', async (req, res) => {
   }
 
   res.status(200).json(response)
+})
+
+// 공고 지원자 상세 조회
+recruitRouter.get('/applications/:application_id', async (req, res) => {
+  const isLoggedIn = Boolean(req.headers.authorization)
+  if (!isLoggedIn) {
+    res.status(401).json({ detail: '로그인이 필요한 기능입니다.' })
+  }
+
+  const applicationId = Number(req.params.application_id)
+  const application = dummyApplicantDetail.find(
+    (application) => application.id === applicationId
+  )
+  if (!application) {
+    return res.status(404).json({ error: '데이터를 찾을 수 없습니다.' })
+  }
+
+  return res.status(200).json(application)
 })
 
 //북마크


### PR DESCRIPTION
> 제목은 이런 형식으로 작성해주세요
>
> #{이슈 번호} {이슈 제목}

> 아래 # 뒤에 이슈 번호를 적어주세요
>
> 그러면 병합 시 자동으로 해당 이슈가 닫힙니다.

close #48 

## 📸 스크린샷

<img width="1605" height="1001" alt="스크린샷 2025-11-10 오전 7 19 02" src="https://github.com/user-attachments/assets/e781cfef-d132-4424-9fcd-3b933c7f2d0d" />

## 📝 작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요

1. 지원자 상세 정보를 조회하는 GET API를 추가했습니다.
2. 요청 파라미터로 전달되는 application_id에 해당하는 지원자의 상세 정보를 응답으로 반환하도록 구현했습니다.
