### PR TITLE
#50 지원자 상세 조회 모달__post API 제작

### DIFF
--- a/src/routers/recruit/recruitRouter.ts
+++ b/src/routers/recruit/recruitRouter.ts
@@ -232,6 +232,44 @@ recruitRouter.get('/applications/:application_id', async (req, res) => {
   return res.status(200).json(application)
 })
 
+// 지원자 승인/거절 통합 API
+recruitRouter.post('/applications/:application_id', async (req, res) => {
+  const isLoggedIn = Boolean(req.headers.authorization)
+  if (!isLoggedIn) {
+    return res.status(401).json({ detail: '권한이 없습니다.' })
+  }
+
+  const applicationId = Number(req.params.application_id)
+  const application = dummyApplicantDetail.find(
+    (applicant) => applicant.id === applicationId
+  )
+
+  const { status } = req.body
+
+  if (!application) {
+    return res.status(404).json({ error: '지원 내역을 찾을 수 없습니다.' })
+  }
+
+  if (application.status !== 'PENDING') {
+    return res
+      .status(400)
+      .json({ error: '이미 승인되거나 거절된 지원 내역입니다.' })
+  }
+
+  dummyApplicantDetail[applicationId] = { ...application, status: status }
+
+  console.log(dummyApplicantDetail[applicationId])
+
+  const updatedApplication = {
+    application_id: applicationId,
+    status: status,
+    approved_at: new Date().toISOString(),
+    member_registered: status ? true : false,
+  }
+
+  return res.status(200).json(updatedApplication)
+})
+
 // //북마크
 // recruitRouter.post('/:id/bookmark', async (req, res) => {
 //   const manage_id = Number(req.params.id)


### PR DESCRIPTION
> 제목은 이런 형식으로 작성해주세요
>
> #{이슈 번호} {이슈 제목}

> 아래 # 뒤에 이슈 번호를 적어주세요
>
> 그러면 병합 시 자동으로 해당 이슈가 닫힙니다.

close #50 

## 📸 스크린샷

<img width="1605" height="1001" alt="스크린샷 2025-11-11 오후 2 09 21" src="https://github.com/user-attachments/assets/2e034627-66a1-4341-a982-d29b2b7a3ae4" />

## 📝 작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요

1. 지원자 승인/거절 기능을 위한 POST API를 구현했습니다.
2. 현재 해당 API의 명세서가 수정 중이며, 승인/거절 상태를 구분하는 방식(body or params or 엔드포인트)이 명확히 정의되지 않아 백엔드 측에 확인 요청을 드린 상태입니다. 
백엔드 답변이 오기 전까지는 임시로 req.body에서 status 값을 받아 처리하도록 구현했습니다.
백엔드 명세 확정 후 로직을 수정할 예정입니다.