### PR TITLE
#67 헤더__알림 드롭다운__응답에 counts 추가

### DIFF
--- a/src/interfaces/_notificationInterfaces.ts
+++ b/src/interfaces/_notificationInterfaces.ts
@@ -21,7 +21,7 @@ export interface Notification {
   updated_at: string
 }
 
-export const notificationTabArray = ['all', 'unread', 'read'] as const
+export const notificationTabArray = ['total', 'unread', 'read'] as const
 export type NotificationTab = (typeof notificationTabArray)[number]
 
 export type NotificationCounts = Record<NotificationTab, number>

--- a/src/interfaces/_notificationInterfaces.ts
+++ b/src/interfaces/_notificationInterfaces.ts
@@ -21,9 +21,15 @@ export interface Notification {
   updated_at: string
 }
 
+export const notificationTabArray = ['all', 'unread', 'read'] as const
+export type NotificationTab = (typeof notificationTabArray)[number]
+
+export type NotificationCounts = Record<NotificationTab, number>
+
 // NOTE: 엔드포인트가 notifications라서 복수형으로 썼습니다
 export interface NotificationsResponseData {
   count: number
+  counts: NotificationCounts
   next: string | null
   previous: string | null
   results: Notification[]

--- a/src/routers/notifications/notificationsRouters.ts
+++ b/src/routers/notifications/notificationsRouters.ts
@@ -10,6 +10,7 @@ import { sleep } from '../utils/sleep.js'
 const notificationsRouter = express.Router()
 
 notificationsRouter.get('/', async (req, res) => {
+  console.log('---- noti get')
   // NOTE: 스켈레톤 확인용입니다
   await sleep(1000)
 
@@ -54,6 +55,7 @@ notificationsRouter.get('/', async (req, res) => {
 })
 
 notificationsRouter.patch('/:notificationId/read', async (req, res) => {
+  console.log('---- noti patch one')
   const notificationId = Number(req.params.notificationId || 0)
 
   const newNotificationArray = dummyNotifications.map((notification) =>
@@ -77,6 +79,7 @@ export default dummyNotifications
 })
 
 notificationsRouter.patch('/read-all', async (_req, res) => {
+  console.log('---- noti patch all')
   const newNotificationArray = dummyNotifications.map((notification) => ({
     ...notification,
     is_read: true,

--- a/src/routers/notifications/notificationsRouters.ts
+++ b/src/routers/notifications/notificationsRouters.ts
@@ -1,4 +1,7 @@
-import type { NotificationsResponseData } from '@/interfaces/index.js'
+import type {
+  NotificationCounts,
+  NotificationsResponseData,
+} from '@/interfaces/index.js'
 import express from 'express'
 import dummyNotifications from './_dummyNotifications.js'
 import fs from 'fs'
@@ -27,6 +30,13 @@ notificationsRouter.get('/', async (req, res) => {
   )
 
   const count = filteredDummy.length
+  const counts: NotificationCounts = {
+    all: dummyNotifications.length,
+    read: dummyNotifications.filter((notification) => notification.is_read)
+      .length,
+    unread: dummyNotifications.filter((notification) => !notification.is_read)
+      .length,
+  }
   const totalPage = Math.ceil(count / page_size)
   const baseUrl = `----not-that-important----/notifications/?is_read=${is_read ? is_read : ''}&page=`
   const previous = page === 1 ? null : `${baseUrl}${page - 1}`
@@ -34,6 +44,7 @@ notificationsRouter.get('/', async (req, res) => {
 
   const response: NotificationsResponseData = {
     count: filteredDummy.length,
+    counts,
     previous,
     next,
     results: slicedDummy,

--- a/src/routers/notifications/notificationsRouters.ts
+++ b/src/routers/notifications/notificationsRouters.ts
@@ -32,7 +32,7 @@ notificationsRouter.get('/', async (req, res) => {
 
   const count = filteredDummy.length
   const counts: NotificationCounts = {
-    all: dummyNotifications.length,
+    total: dummyNotifications.length,
     read: dummyNotifications.filter((notification) => notification.is_read)
       .length,
     unread: dummyNotifications.filter((notification) => !notification.is_read)


### PR DESCRIPTION
> 제목은 이런 형식으로 작성해주세요
>
> #{이슈 번호} {이슈 제목}

> 아래 # 뒤에 이슈 번호를 적어주세요
>
> 그러면 병합 시 자동으로 해당 이슈가 닫힙니다.

close #67

## 📸 스크린샷

<img width="1138" height="786" alt="image" src="https://github.com/user-attachments/assets/83f1f0d1-99d1-4eec-9858-a61c96b590cb" />


## 📝 작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요

1. 응답에 counts 객체를 함께 보냅니다. 여기에는 각 종류별 알림 수가 들어있습니다
2. 포스트맨에서 http://localhost:3000/notifications 으로 테스트하실 수 있습니다.

현재 이 부분은 백엔드 2팀에게 요청만 드렸고 아직 답변은 못 받았습니다.
다만, 페이지별로 알림을 받는 기존 구조상, 프론트엔드에서 불충분한 자료로 필터링하여 보여주는 것보단 백엔드에서 처음부터 보내주는 게 합리적일 것 같아 이 방향으로 설득해보려 합니다.
